### PR TITLE
fix: `he` breaks vite, replace with `entities`

### DIFF
--- a/.changeset/purple-dots-end.md
+++ b/.changeset/purple-dots-end.md
@@ -1,0 +1,30 @@
+---
+"astro-remote": patch
+---
+
+`he` breaks vite, replace with entities
+
+When using CodeBlock / CodeSpan.
+
+Stack trace:
+
+```sh
+TypeError: __vite_ssr_import_5__.encode is not a function
+Please report this to https://github.com/markedjs/marked.
+    at renderer.code (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/utils.ts:76:60)
+    at renderer.<computed> [as code] (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2751:41)
+    at Parser.parse (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2277:32)
+    at parse (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2211:19)
+    at eval (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2644:18)
+    at Function.marked [as parse] (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2659:48)
+    at Module.markdown (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/utils.ts:92:54)
+    at eval (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/Markdown.astro:17:47)
+    at AstroComponentInstance.Markdown [as factory] (/.../astro-openapi/node_modules/.pnpm/astro@2.1.9/node_modules/astro/dist/runtime/server/astro-component.js:22:12)
+    at AstroComponentInstance.init (/.../astro-openapi/node_modules/.pnpm/astro@2.1.9/node_modules/astro/dist/runtime/server/render/astro/instance.js:28:29)
+```
+
+---
+
+`entities` is typed, and more updated / speedy.
+
+Need more tests though.

--- a/packages/astro-remote/lib/utils.ts
+++ b/packages/astro-remote/lib/utils.ts
@@ -3,9 +3,8 @@ import { transform } from 'ultrahtml';
 import { jsx as h } from 'astro/jsx-runtime';
 import { renderJSX } from 'astro/runtime/server/jsx';
 import { __unsafeHTML } from 'ultrahtml';
-import * as he from 'he';
+import * as entities from "entities";
 
-declare var he: any;
 
 export function createComponentProxy(result, _components: Record<string, any> = {}) {
   const components = {};
@@ -15,7 +14,7 @@ export function createComponentProxy(result, _components: Record<string, any> = 
     } else {
       components[key] = async (props, children) => {
         if (key === 'CodeBlock' || key === 'CodeSpan') {
-          props.code = he.decode(JSON.parse(`"${props.code}"`));
+          props.code = entities.decode(JSON.parse(`"${props.code}"`));
         }
         const output = await renderJSX(
           result,
@@ -79,13 +78,13 @@ export async function markdown(
       renderer.code = (code: string, meta = '') => {
         const info = meta.split(/\s+/g) ?? [];
         const lang = info[0] ?? 'plaintext';
-        const value = JSON.stringify(he.encode(code))
+        const value = JSON.stringify(entities.encode(code))
         return `<CodeBlock lang=${JSON.stringify(lang)} code=${value} ${info.splice(1).join(' ')} />`
       }
     }
     if ('CodeSpan' in opts.components) {
       renderer.codespan = (code: string) => {
-        const value = JSON.stringify(he.encode(code))
+        const value = JSON.stringify(entities.encode(code))
         return `<CodeSpan code=${value}>${code}</CodeSpan>`
       }
     }

--- a/packages/astro-remote/package.json
+++ b/packages/astro-remote/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "he": "^1.2.0",
+    "entities": "^4.4.0",
     "marked": "^4.0.18",
     "ultrahtml": "^0.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
   packages/astro-remote:
     specifiers:
       astro: 1.3.0
-      he: ^1.2.0
+      entities: ^4.4.0
       marked: ^4.0.18
       ultrahtml: ^0.1.1
     dependencies:
-      he: 1.2.0
+      entities: 4.4.0
       marked: 4.0.18
       ultrahtml: 0.1.1
     devDependencies:
@@ -1411,6 +1411,11 @@ packages:
       ansi-colors: 4.1.3
     dev: false
 
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+    engines: {node: '>=0.12'}
+    dev: false
+
   /eol/0.9.1:
     resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
     dev: true
@@ -2283,11 +2288,6 @@ packages:
       property-information: 6.1.1
       space-separated-tokens: 2.0.1
     dev: true
-
-  /he/1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
-    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}


### PR DESCRIPTION
When using CodeBlock / CodeSpan.

Stack trace:

```sh
TypeError: __vite_ssr_import_5__.encode is not a function
Please report this to https://github.com/markedjs/marked.
    at renderer.code (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/utils.ts:76:60)
    at renderer.<computed> [as code] (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2751:41)
    at Parser.parse (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2277:32)
    at parse (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2211:19)
    at eval (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2644:18)
    at Function.marked [as parse] (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/node_modules/marked/lib/marked.esm.js:2659:48)
    at Module.markdown (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/utils.ts:92:54)
    at eval (/.../web-garden/themes/simple-docs/node_modules/.pnpm/astro-remote@0.2.3/node_modules/astro-remote/lib/Markdown.astro:17:47)
    at AstroComponentInstance.Markdown [as factory] (/.../astro-openapi/node_modules/.pnpm/astro@2.1.9/node_modules/astro/dist/runtime/server/astro-component.js:22:12)
    at AstroComponentInstance.init (/.../astro-openapi/node_modules/.pnpm/astro@2.1.9/node_modules/astro/dist/runtime/server/render/astro/instance.js:28:29)
```

---

`entities` is typed, and more updated / speedy.

Need more tests though.