### PR TITLE
Chore: Update playground package.json to private

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -2,6 +2,7 @@
   "name": "playground",
   "type": "module",
   "version": "0.0.1",
+  "private": "true",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
This PR fixes the failing Github Action, That is failing due to the missing `"private": "true"` in the playground.