### PR TITLE
Chore: fix markdown dedent function

### DIFF
--- a/.changeset/silent-insects-explode.md
+++ b/.changeset/silent-insects-explode.md
@@ -1,0 +1,5 @@
+---
+"astro-remote": patch
+---
+
+Fixes an issue with internal `dedent` function used for spacing/linebreak corrections for `Markdown`

--- a/packages/astro-remote/lib/utils.ts
+++ b/packages/astro-remote/lib/utils.ts
@@ -49,8 +49,9 @@ export function dedent(str: string): string {
     if (indent.length === 0 && lns.length > 1) {
         indent = getIndent(lns[1]);
     }
+		if (indent.length === 0) return lns.join("\n");
     return lns
-        .map((ln) => (indent.length > 1 && ln.startsWith(indent) ? ln.slice(indent.length) : ln))
+        .map(ln => ln.startsWith(indent) ? ln.slice(indent.length) : ln)
         .join("\n");
 }
 

--- a/packages/astro-remote/lib/utils.ts
+++ b/packages/astro-remote/lib/utils.ts
@@ -44,15 +44,14 @@ function getIndent(ln: string): string {
 }
 
 export function dedent(str: string): string {
-	const lns = str.replace(/^[\r\n]+/, "").split("\n");
-	let indent = getIndent(lns[0]);
-	if (indent.length === 0 && lns.length > 1) {
-		indent = getIndent(lns[1]);
-	}
-	return lns
-		.map((ln) => (ln.startsWith(indent) ? ln.slice(indent.length) : ln))
-		.map((ln, i, { length }) => (i === length - 1 ? ln.trim() : ln))
-		.join("\n");
+    const lns = str.replace(/^[\r\n]+/, "").split("\n");
+    let indent = getIndent(lns[0]);
+    if (indent.length === 0 && lns.length > 1) {
+        indent = getIndent(lns[1]);
+    }
+    return lns
+        .map((ln) => (indent.length > 1 && ln.startsWith(indent) ? ln.slice(indent.length) : ln))
+        .join("\n");
 }
 
 export interface HTMLOptions {

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -13,6 +13,7 @@
 	  <h2>Local:</h2>
 		<ul>
 			<li><a href="/test-md-local">Test Local Markdown "< Markdown >"</a></li>
+			<li><a href="/test-issue7">Test Issue #7</a></li>
 		</ul>
 	  <h2>Remote:</h2>
 		<ul>

--- a/packages/playground/src/pages/test-issue7.astro
+++ b/packages/playground/src/pages/test-issue7.astro
@@ -1,19 +1,10 @@
 ---
 import { Markdown } from "astro-remote";
 
-// Working as expected
-const c0 = `Most .`;
-
-// 1 space
-const c1 = `Most \\
-.`;
-
-// 2 spaces
-const c2 = `Most  \\
-.`;
-
-// Space at the end
-const c3 = `Most . `;
+const c0 = "Most .";
+const c1 = "Most \n.";
+const c2 = "Most  \n.";
+const c3 = "Most . ";
 
 const content = [c0, c1, c2, c3];
 ---

--- a/packages/playground/src/pages/test-issue7.astro
+++ b/packages/playground/src/pages/test-issue7.astro
@@ -5,7 +5,7 @@ import { Markdown } from "astro-remote";
 const c0 = `Most .`;
 
 // 1 space
-const c1 = `Most \
+const c1 = `Most \\
 .`;
 
 // 2 spaces
@@ -13,7 +13,7 @@ const c2 = `Most  \\
 .`;
 
 // Space at the end
-const c3 = `Most .\ `;
+const c3 = `Most . `;
 
 const content = [c0, c1, c2, c3];
 ---

--- a/packages/playground/src/pages/test-issue7.astro
+++ b/packages/playground/src/pages/test-issue7.astro
@@ -1,0 +1,22 @@
+---
+import { Markdown } from "astro-remote";
+
+// Working as expected
+const c0 = `Most .`;
+
+// 1 space
+const c1 = `Most \
+.`;
+
+// 2 spaces
+const c2 = `Most  \\
+.`;
+
+// Space at the end
+const c3 = `Most .\ `;
+
+const content = [c0, c1, c2, c3];
+---
+<div>
+    {content.map((c) => <Markdown>{c}</Markdown>)}
+</div>

--- a/packages/playground/src/pages/test-md-local.astro
+++ b/packages/playground/src/pages/test-md-local.astro
@@ -10,6 +10,7 @@ const readme = `
 # Hello \`world\`
 
 > [!NOTE]
+> This is a Note Using MarkedAlert Marked Extension\\
 > This is just a test
 
 > **Note**


### PR DESCRIPTION
This PR resolves Issue #7 by updating the internal `dedent` function to better handle line breaks and whitespaces. And prevent removal of actual characters.  See internal `test-issue7` from the playground.