### PR TITLE
fix: incorrectly removing initial characters due to trailing whitespace

### DIFF
--- a/.changeset/selfish-radios-talk.md
+++ b/.changeset/selfish-radios-talk.md
@@ -1,0 +1,5 @@
+---
+"astro-remote": patch
+---
+
+Fixes an issue with internal `getIndent` function used for spacing corrections for `Markdown`

--- a/packages/astro-remote/lib/utils.ts
+++ b/packages/astro-remote/lib/utils.ts
@@ -39,8 +39,8 @@ export function createComponentProxy(
 }
 
 function getIndent(ln: string): string {
-	if (ln.trim() === ln) return "";
-	return ln.slice(0, ln.length - ln.trim().length);
+	if (ln.trimStart() === ln) return "";
+	return ln.slice(0, ln.length - ln.trimStart().length);
 }
 
 export function dedent(str: string): string {

--- a/packages/playground/src/pages/index.astro
+++ b/packages/playground/src/pages/index.astro
@@ -14,6 +14,7 @@
 		<ul>
 			<li><a href="/test-md-local">Test Local Markdown "< Markdown >"</a></li>
 			<li><a href="/test-issue7">Test Issue #7</a></li>
+			<li><a href="/test-issue27">Test Issue #27</a></li>
 		</ul>
 	  <h2>Remote:</h2>
 		<ul>

--- a/packages/playground/src/pages/test-issue27.astro
+++ b/packages/playground/src/pages/test-issue27.astro
@@ -1,0 +1,18 @@
+---
+import { Markdown } from "astro-remote";
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+	</head>
+	<body>
+		<Markdown content={"<mark>Highlighted word</mark> with no trailing space"} />
+		<Markdown content={"<mark>Highlighted word</mark> with trailing space "} />
+		<Markdown content={"Non-initial <mark>Highlighted word</mark> with trailing spaces   "} />
+	</body>
+</html>


### PR DESCRIPTION
This PR resolves issue #27 by updating the internal `getIndent` function to use `trimStart` instead of `trim` so that it only counts whitespace at the beginning.
See internal `test-issue27` from the playground.